### PR TITLE
fix: implementar limpeza de cookies HTTP-only no logout

### DIFF
--- a/frontend/src/app/(dashboard)/orders/new/page.tsx
+++ b/frontend/src/app/(dashboard)/orders/new/page.tsx
@@ -29,8 +29,6 @@ import {
   useColorModeValue,
   Card,
   CardBody,
-  Container,
-  Icon,
   useBreakpointValue,
 } from '@chakra-ui/react'
 import {
@@ -42,7 +40,6 @@ import {
   Wrench,
   Package,
   DollarSign,
-  AlertTriangle,
   CheckCircle,
   Plus
 } from 'lucide-react'

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  try {
+    const response = NextResponse.json({ message: 'Logout realizado com sucesso' })
+    
+    // Limpar o cookie de autenticação
+    response.cookies.set('@ti-assistant:token', '', {
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+      expires: new Date(0), // Define a data de expiração para o passado
+      maxAge: 0, // Define maxAge como 0
+    })
+    
+    return response
+  } catch (error) {
+    console.error('[API][auth][logout][POST] Erro:', error)
+    return NextResponse.json(
+      { message: 'Erro ao fazer logout' },
+      { status: 500 }
+    )
+  }
+} 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -52,7 +52,19 @@ const SidebarContent = ({ onClose }: { onClose: () => void }) => {
   console.log('Sidebar - isAuthenticated:', isAuthenticated)
   console.log('Sidebar - User role:', user?.role)
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    try {
+      // Chamar API para limpar cookies HTTP-only
+      await fetch('/api/auth/logout', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    } catch (error) {
+      console.error('Erro ao fazer logout:', error)
+    }
+    
     // Limpar todos os itens do localStorage que começam com @ti-assistant:
     Object.keys(localStorage).forEach(key => {
       if (key.startsWith('@ti-assistant:')) {
@@ -70,6 +82,7 @@ const SidebarContent = ({ onClose }: { onClose: () => void }) => {
     localStorage.removeItem('selectedCategory')
     localStorage.removeItem('chakra-ui-color-mode')
     
+    // Redirecionar para a página de login
     router.push('/')
   }
 

--- a/frontend/src/contexts/GlobalContext.tsx
+++ b/frontend/src/contexts/GlobalContext.tsx
@@ -397,8 +397,20 @@ export function GlobalProvider({ children }: GlobalProviderProps) {
     }
   }, [state.inventoryLastFetched]);
 
-  // Limpar localStorage no logout
-  const handleLogout = () => {
+  // Limpar localStorage e cookies no logout
+  const handleLogout = async () => {
+    try {
+      // Chamar API para limpar cookies HTTP-only
+      await fetch('/api/auth/logout', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    } catch (error) {
+      console.error('Erro ao fazer logout:', error)
+    }
+    
     localStorage.removeItem('@ti-assistant:user');
     localStorage.removeItem('@ti-assistant:token');
     localStorage.removeItem('@ti-assistant:cart');

--- a/frontend/src/lib/axios.ts
+++ b/frontend/src/lib/axios.ts
@@ -17,11 +17,23 @@ api.interceptors.request.use((config) => {
 
 api.interceptors.response.use(
     (response) => response,
-    (error) => {
+    async (error) => {
         if (error.response?.status === 401) {
+            try {
+                // Limpar cookies HTTP-only
+                await fetch('/api/auth/logout', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                })
+            } catch (logoutError) {
+                console.error('Erro ao limpar cookies no logout:', logoutError)
+            }
+            
             localStorage.removeItem('@ti-assistant:token')
             localStorage.removeItem('@ti-assistant:user')
-            window.location.href = '/login'
+            window.location.href = '/'
         }
         return Promise.reject(error)
     }


### PR DESCRIPTION
- Criar nova API route /api/auth/logout para limpar cookies
- Atualizar Sidebar.tsx para chamar API de logout
- Atualizar GlobalContext para limpar cookies no logout
- Atualizar interceptor do axios para limpar cookies em erro 401
- Resolver problema de cookies não serem limpos no botão sair