### PR TITLE
chore: remover cookie do token via document.cookie antes de chamar /a…

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -54,6 +54,8 @@ const SidebarContent = ({ onClose }: { onClose: () => void }) => {
 
   const handleLogout = async () => {
     try {
+      // deleta o cookie do token @ti-assistant:token do navegador imediatamente
+      document.cookie = '@ti-assistant:token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;'
       // Chamar API para limpar cookies HTTP-only
       await fetch('/api/auth/logout', {
         method: 'POST',


### PR DESCRIPTION
…pi/auth/logout

- Adiciona remoção imediata do cookie @ti-assistant:token no cliente
- Mantém chamada à API de logout para garantir limpeza do cookie httpOnly
- Melhora robustez do fluxo de logout no Sidebar