### PR TITLE
fix(supply-requests): E2E admin estável, modal sem crash e Jest sem c…

### DIFF
--- a/frontend/jest.e2e.config.js
+++ b/frontend/jest.e2e.config.js
@@ -5,6 +5,8 @@ module.exports = {
     testMatch: ['**/tests/e2e/**/*.test.ts'],
     /** E2E: vários `driver.wait` (60s) + navegação; margem para CI lento. */
     testTimeout: 180000,
+    /** Evita colisão Haste com `package.json` dentro de `.next/standalone` após `next build`. */
+    modulePathIgnorePatterns: ['<rootDir>/.next/'],
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,9 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:e2e": "jest --config jest.e2e.config.js"
+    "test:e2e": "jest --config jest.e2e.config.js",
+    "test:e2e:headed": "E2E_HEADLESS=0 jest --config jest.e2e.config.js",
+    "test:e2e:ci": "E2E_HEADLESS=1 jest --config jest.e2e.config.js"
   },
   "dependencies": {
     "@auth/core": "^0.34.2",

--- a/frontend/src/app/(dashboard)/supply-requests/admin/page.tsx
+++ b/frontend/src/app/(dashboard)/supply-requests/admin/page.tsx
@@ -281,6 +281,7 @@ function PersistentTabsLayout({ tabLabels, children, onTabChange, storageKey = '
                             return (
                                 <Tab
                                     key={label}
+                                    data-testid={index === 0 ? 'admin-tab-suprimentos' : undefined}
                                     _selected={{ bg: tabSelectedBg, color: tabSelectedColor, boxShadow: 'sm', border: '1px solid', borderColor: tabSelectedBorder }}
                                     _hover={{ bg: tabHoverBg }}
                                     transition="all 0.2s ease"

--- a/frontend/src/app/(dashboard)/supply-requests/components/CustomSupplyRequestModal.tsx
+++ b/frontend/src/app/(dashboard)/supply-requests/components/CustomSupplyRequestModal.tsx
@@ -84,7 +84,8 @@ function createEmptyLine(): LineState {
 }
 
 /** Nome, quantidade válida e unidade — campos obrigatórios do item. */
-function isLineComplete(line: LineState): boolean {
+function isLineComplete(line: LineState | undefined): boolean {
+    if (!line) return false;
     return (
         Boolean(line.item_name?.trim()) &&
         Number(line.quantity) >= 1 &&
@@ -119,6 +120,12 @@ export function CustomSupplyRequestModal({
             setDeliveryDeadline('');
         }
     }, [isOpen]);
+
+    /** Evita `expandedLineIndex` fora do intervalo (ex.: após remoções ou atualizações de estado). */
+    useEffect(() => {
+        if (lines.length === 0) return;
+        setExpandedLineIndex((i) => Math.min(i, lines.length - 1));
+    }, [lines.length]);
 
     const fetchUnits = async () => {
         try {

--- a/frontend/tests/e2e/custom-supply-request.test.ts
+++ b/frontend/tests/e2e/custom-supply-request.test.ts
@@ -27,16 +27,33 @@
  * - `E2E_EMAIL` / `E2E_PASSWORD` — sobrescrevem o usuário padrão do seed (`usuario@example.com`).
  * - `E2E_MANAGER_EMAIL` — e-mail do gerente para o passo “visão admin” (padrão: `gerente@example.com`; mesma senha que `E2E_PASSWORD` / seed).
  * - `E2E_SKIP=1` — ignora a suíte (útil em CI sem stack ou Chrome).
- * - `E2E_HEADLESS=1` — opcional; roda Chrome em modo headless (útil em CI).
+ * - `E2E_HEADLESS=1` — opcional; roda Chrome em modo **headless** (útil em CI). Por omissão o Chrome abre
+ *   **janela visível**; se não vir o navegador, confirme que `E2E_HEADLESS` não está a `1` no ambiente e use
+ *   `npm run test:e2e:headed` para forçar modo com janela.
  *
  * Execução:
  *   npm run test:e2e
+ *   npm run test:e2e:headed   # força janela visível (ignora E2E_HEADLESS=1 no shell)
  *
  * Dentro de cada suíte, os `it` rodam em sequência no mesmo navegador dessa suíte.
  */
 
 import { Builder, By, until, WebDriver, WebElement } from 'selenium-webdriver';
 import * as chrome from 'selenium-webdriver/chrome';
+
+/** Só headless com opt-in explícito — em desenvolvimento local o Chrome deve mostrar janela. */
+function buildChromeOptions(): chrome.Options {
+    const options = new chrome.Options();
+    if (process.env.E2E_HEADLESS === '1') {
+        options.addArguments('--headless=new', '--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage');
+    }
+    options.addArguments('--window-size=1400,900');
+    return options;
+}
+
+async function createChromeDriver(): Promise<WebDriver> {
+    return new Builder().forBrowser('chrome').setChromeOptions(buildChromeOptions()).build();
+}
 
 const baseUrl = (process.env.E2E_BASE_URL || 'http://localhost:3002').replace(/\/$/, '');
 
@@ -106,11 +123,20 @@ async function e2eLogin(driver: WebDriver, mail: string, pass: string) {
  * Input Chakra controlado: define `value` e dispara eventos.
  */
 async function adminSearchSupplies(driver: WebDriver, query: string) {
-    // Tabs podem ser `button` ou outro nó com `role="tab"` (Chakra).
+    // Preferir data-testid (estável); fallback XPath para builds antigos.
     const supTab = await driver.wait(
-        until.elementLocated(By.xpath("//*[@role='tab' and contains(., 'Suprimentos')]")),
-        30000
+        async () => {
+            const byTestId = await driver.findElements(By.css('[data-testid="admin-tab-suprimentos"]'));
+            if (byTestId.length > 0) return byTestId[0];
+            const byRole = await driver.findElements(
+                By.xpath("//*[@role='tab' and contains(., 'Suprimentos')]")
+            );
+            return byRole[0];
+        },
+        60000,
+        'Aba Suprimentos em /supply-requests/admin'
     );
+    await driver.wait(until.elementIsVisible(supTab), 15000);
     await supTab.click();
 
     let searchInput: WebElement | undefined;
@@ -225,12 +251,7 @@ async function selectNativeOptionByIndex(driver: WebDriver, selectEl: WebElement
     let singleItemMarker: number;
 
     beforeAll(async () => {
-        const options = new chrome.Options();
-        if (process.env.E2E_HEADLESS === '1') {
-            options.addArguments('--headless=new', '--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage');
-        }
-        options.addArguments('--window-size=1400,900');
-        driver = await new Builder().forBrowser('chrome').setChromeOptions(options).build();
+        driver = await createChromeDriver();
     });
 
     afterAll(async () => {
@@ -420,12 +441,7 @@ async function selectNativeOptionByIndex(driver: WebDriver, selectEl: WebElement
     let batchId: number;
 
     beforeAll(async () => {
-        const options = new chrome.Options();
-        if (process.env.E2E_HEADLESS === '1') {
-            options.addArguments('--headless=new', '--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage');
-        }
-        options.addArguments('--window-size=1400,900');
-        driver = await new Builder().forBrowser('chrome').setChromeOptions(options).build();
+        driver = await createChromeDriver();
     });
 
     afterAll(async () => {


### PR DESCRIPTION
…olisão .next

- Modal: isLineComplete com linha indefinida; clamp de expandedLineIndex
- Admin: data-testid na aba Suprimentos; E2E usa testid + fallback e 60s
- jest.e2e: modulePathIgnorePatterns para .next (standalone)
- Scripts test:e2e:headed / :ci em package.json (se aplicável ao diff)

Made-with: Cursor